### PR TITLE
Bump Deno runtime to 2.7.9, oak@17.2.0 and Docker actions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.5.3
+FROM denoland/deno:2.7.9
 
 # Install tools
 RUN apt-get update && \

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Deno v2.5.3
+      - name: Setup Deno v2.7.9
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5.3
+          deno-version: v2.7.9
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov
@@ -35,7 +35,7 @@ jobs:
         run: deno task cover
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6.0.0
+        uses: sonarsource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''
@@ -51,20 +51,20 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           platforms: linux/amd64,linux/arm64
@@ -77,12 +77,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: 'master'
 
       - name: Checkout Kustomize
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ARGOCD_PAT }}
           repository: switcherapi/switcher-deployment

--- a/.github/workflows/re-release.yml
+++ b/.github/workflows/re-release.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
 
-      - name: Setup Deno v2.5.3
+      - name: Setup Deno v2.7.9
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5.3
+          deno-version: v2.7.9
 
       - name: Verify formatting
         run: deno task fmt
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
@@ -54,19 +54,19 @@ jobs:
           tags: ${{ github.event.inputs.tag }}
       
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Deno v2.5.3
+      - name: Setup Deno v2.7.9
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5.3
+          deno-version: v2.7.9
 
       - name: Verify formatting
         run: deno task fmt
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Docker meta
         id: meta
@@ -45,19 +45,19 @@ jobs:
           images: trackerforce/switcher-management-feature
       
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,15 +28,15 @@ jobs:
             core.setOutput('base_ref', pr.data.base.ref);
             core.setOutput('head_sha', pr.data.head.sha);
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
-      - name: Setup Deno v2.5.3
+      - name: Setup Deno v2.7.9
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5.3
+          deno-version: v2.7.9
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov
@@ -51,7 +51,7 @@ jobs:
         run: deno task cover
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6.0.0
+        uses: sonarsource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-2.5.3
+FROM denoland/deno:alpine-2.7.9
 
 ENV APP_HOME=/home/app
 WORKDIR $APP_HOME

--- a/deno.lock
+++ b/deno.lock
@@ -2,36 +2,34 @@
   "version": "5",
   "specifiers": {
     "jsr:@oak/commons@1": "1.0.1",
-    "jsr:@oak/oak@17.1.6": "17.1.6",
-    "jsr:@std/assert@1": "1.0.15",
-    "jsr:@std/assert@1.0.14": "1.0.14",
-    "jsr:@std/assert@^1.0.13": "1.0.15",
+    "jsr:@oak/oak@17.2.0": "17.2.0",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@1.0.19": "1.0.19",
+    "jsr:@std/assert@^1.0.13": "1.0.19",
     "jsr:@std/bytes@1": "1.0.6",
-    "jsr:@std/cli@^1.0.23": "1.0.23",
+    "jsr:@std/cli@^1.0.28": "1.0.28",
     "jsr:@std/crypto@1": "1.0.5",
-    "jsr:@std/dotenv@0.225.5": "0.225.5",
+    "jsr:@std/dotenv@0.225.6": "0.225.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
-    "jsr:@std/fmt@1.0.8": "1.0.8",
-    "jsr:@std/fmt@^1.0.8": "1.0.8",
+    "jsr:@std/fmt@1.0.9": "1.0.9",
+    "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.19": "1.0.19",
-    "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/html@^1.0.5": "1.0.5",
-    "jsr:@std/http@1": "1.0.21",
-    "jsr:@std/http@^1.0.16": "1.0.21",
-    "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/http@1": "1.0.25",
+    "jsr:@std/http@^1.0.16": "1.0.25",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.9": "1.0.12",
     "jsr:@std/media-types@1": "1.1.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.6": "1.0.6",
-    "jsr:@std/path@1": "1.1.2",
-    "jsr:@std/path@^1.1.1": "1.1.2",
-    "jsr:@std/path@^1.1.2": "1.1.2",
-    "jsr:@std/streams@^1.0.13": "1.0.13",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/streams@^1.0.17": "1.0.17",
     "jsr:@switcherapi/switcher-client-deno@2.4.0": "2.4.0",
     "jsr:@trackerforce/validator4oak@1.3.0": "1.3.0",
-    "npm:@types/node@*": "24.2.0",
     "npm:path-to-regexp@^6.3.0": "6.3.0"
   },
   "jsr": {
@@ -46,8 +44,8 @@
         "jsr:@std/media-types@1"
       ]
     },
-    "@oak/oak@17.1.6": {
-      "integrity": "c7eef2eec733fba8e72b679bba3b8cf2fceccf5ef489a8b8fb43571908c0335d",
+    "@oak/oak@17.2.0": {
+      "integrity": "938537a92fc7922a46a9984696c65fb189c9baad164416ac3e336768a9ff0cd1",
       "dependencies": [
         "jsr:@oak/commons",
         "jsr:@std/assert@1",
@@ -58,14 +56,8 @@
         "npm:path-to-regexp"
       ]
     },
-    "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.10"
-      ]
-    },
-    "@std/assert@1.0.15": {
-      "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal@^1.0.12"
       ]
@@ -73,20 +65,20 @@
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "@std/cli@1.0.23": {
-      "integrity": "bf95b7a9425ba2af1ae5a6359daf58c508f2decf711a76ed2993cd352498ccca"
+    "@std/cli@1.0.28": {
+      "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
     "@std/crypto@1.0.5": {
       "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
     },
-    "@std/dotenv@0.225.5": {
-      "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
+    "@std/dotenv@0.225.6": {
+      "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
     },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
     },
     "@std/fs@1.0.19": {
       "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
@@ -95,20 +87,23 @@
         "jsr:@std/path@^1.1.1"
       ]
     },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
+    },
     "@std/html@1.0.5": {
       "integrity": "4e2d693f474cae8c16a920fa5e15a3b72267b94b84667f11a50c6dd1cb18d35e"
     },
-    "@std/http@1.0.21": {
-      "integrity": "abb5c747651ee6e3ea6139858fd9b1810d2c97f53a5e6722f3b6d27a6d263edc",
+    "@std/http@1.0.25": {
+      "integrity": "577b4252290af1097132812b339fffdd55fb0f4aeb98ff11bdbf67998aa17193",
       "dependencies": [
         "jsr:@std/cli",
         "jsr:@std/encoding@^1.0.10",
-        "jsr:@std/fmt@^1.0.8",
-        "jsr:@std/fs@^1.0.19",
+        "jsr:@std/fmt@^1.0.9",
+        "jsr:@std/fs@^1.0.23",
         "jsr:@std/html",
         "jsr:@std/media-types@^1.1.0",
         "jsr:@std/net",
-        "jsr:@std/path@^1.1.2",
+        "jsr:@std/path@^1.1.4",
         "jsr:@std/streams"
       ]
     },
@@ -121,14 +116,14 @@
     "@std/net@1.0.6": {
       "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
     },
-    "@std/path@1.1.2": {
-      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal@^1.0.10"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/streams@1.0.13": {
-      "integrity": "772d208cd0d3e5dac7c1d9e6cdb25842846d136eea4a41a62e44ed4ab0c8dd9e"
+    "@std/streams@1.0.17": {
+      "integrity": "7859f3d9deed83cf4b41f19223d4a67661b3d3819e9fc117698f493bf5992140"
     },
     "@switcherapi/switcher-client-deno@2.4.0": {
       "integrity": "7fea9e619caec812e53188387c2f145022c368e1a7eb70cc368c35c936b36fd6",
@@ -141,17 +136,8 @@
     }
   },
   "npm": {
-    "@types/node@24.2.0": {
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
-      "dependencies": [
-        "undici-types"
-      ]
-    },
     "path-to-regexp@6.3.0": {
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
-    },
-    "undici-types@7.10.0": {
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
     }
   },
   "remote": {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
-export { Application, Context, type Middleware, type Next, Router } from 'jsr:@oak/oak@17.1.6';
+export { Application, Context, type Middleware, type Next, Router } from 'jsr:@oak/oak@17.2.0';
 export { Client } from 'jsr:@switcherapi/switcher-client-deno@2.4.0';
 export { ValidatorFn, ValidatorMiddleware } from 'jsr:@trackerforce/validator4oak@1.3.0';
-export { load } from 'jsr:@std/dotenv@0.225.5';
-export { bold, cyan, green } from 'jsr:@std/fmt@1.0.8/colors';
+export { load } from 'jsr:@std/dotenv@0.225.6';
+export { bold, cyan, green } from 'jsr:@std/fmt@1.0.9/colors';

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,4 +1,4 @@
-export { type Middleware, testing } from 'jsr:@oak/oak@17.1.6';
+export { type Middleware, testing } from 'jsr:@oak/oak@17.2.0';
 export { Client, StrategiesType } from 'jsr:@switcherapi/switcher-client-deno@2.4.0';
 export { superoak } from 'https://deno.land/x/superoak@5.0.0/mod.ts';
-export { assert, assertEquals, assertFalse, assertObjectMatch } from 'jsr:@std/assert@1.0.14';
+export { assert, assertEquals, assertFalse, assertObjectMatch } from 'jsr:@std/assert@1.0.19';


### PR DESCRIPTION
This pull request updates the project to use newer versions of Deno, Docker images, GitHub Actions, and several dependencies. The main goal is to ensure compatibility with the latest tooling and improve security and stability across the development, CI/CD, and runtime environments.

**Dependency and Environment Updates:**

* Updated the base Deno Docker images in both `.devcontainer/Dockerfile` and the main `Dockerfile` from version `2.5.3` to `2.7.9` to ensure the development and runtime environments use the latest Deno features and fixes. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R1) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1)

**CI/CD Workflow Improvements:**

* Updated all GitHub Actions in workflow files (`master.yml`, `release.yml`, `re-release.yml`, `sonar.yml`) to use the latest major versions, including `actions/checkout@v6`, `docker/*-action@v4`, and `docker/build-push-action@v7`, improving security and compatibility. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L16-R23) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L54-R67) [[3]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L80-R85) [[4]](diffhunk://#diff-10bf0d1aabdb0cbc7ab276220dc3f633a26f4a46f16cd23a09cb2741fd96d8b1L18-R26) [[5]](diffhunk://#diff-10bf0d1aabdb0cbc7ab276220dc3f633a26f4a46f16cd23a09cb2741fd96d8b1L44-R44) [[6]](diffhunk://#diff-10bf0d1aabdb0cbc7ab276220dc3f633a26f4a46f16cd23a09cb2741fd96d8b1L57-R69) [[7]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R21) [[8]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L39-R39) [[9]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L48-R60) [[10]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L31-R39)
* Updated SonarCloud scan action in CI workflows to `sonarsource/sonarqube-scan-action@v7.0.0` for improved code analysis and integration. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L38-R38) [[2]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L54-R54)

**Application and Test Dependency Updates:**

* Upgraded `@oak/oak` from `17.1.6` to `17.2.0` in both `src/deps.ts` and `tests/deps.ts` to leverage recent framework improvements. [[1]](diffhunk://#diff-148f36f0a365bdf27732ea65daa5ff8c8a9bb768820a50dd689675ba7df9980eL1-R5) [[2]](diffhunk://#diff-57d30fbbf1d1cdb1a5eca860805d6d2f5d96ce1765fbab935fc36b630c707786L1-R4)
* Updated other Deno standard library dependencies to their latest patch versions for better stability and bug fixes: `@std/dotenv`, `@std/fmt/colors`, and `@std/assert`. [[1]](diffhunk://#diff-148f36f0a365bdf27732ea65daa5ff8c8a9bb768820a50dd689675ba7df9980eL1-R5) [[2]](diffhunk://#diff-57d30fbbf1d1cdb1a5eca860805d6d2f5d96ce1765fbab935fc36b630c707786L1-R4)

These changes collectively modernize the stack and help prevent issues related to outdated dependencies and tooling.